### PR TITLE
"use-public-rspm: true" i setup-r-action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
   
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v5
       - name: R setup
         uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - name: Build package (tarball)
         run: R CMD build .
       - name: Lint Dockerfile

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -28,6 +28,8 @@ jobs:
           dockerfile: "Dockerfile"
       - name: R setup
         uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - name: Build package (tarball)
         run: R CMD build .
       - name: Prepare tags

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
For å bruke ferdiginstallerte pakker fra posit under bygging, slik at github actions (forhåpentligvis) går fortere.